### PR TITLE
Add prerequisites to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ This is a monorepo containing:
 | PDF Engine | ReportLab (primary), WeasyPrint (fallback)              |
 | Markdown   | markdown-it-py with table and highlight plugins         |
 
+## Prerequisites
+
+This project has been tested with the following runtime versions:
+
+- **Node.js** 22.x
+- **Python** 3.11
+
 ## Quick Start
 
 For convenience, an ENV install script provided:


### PR DESCRIPTION
## Summary
- document tested Node.js and Python versions in README

## Testing
- `npm run lint` *(fails: `next` not found)*