### PR TITLE
Remove dark mode from PDF preview

### DIFF
--- a/markup2pdf-webapp/app/components/PDFPreview.tsx
+++ b/markup2pdf-webapp/app/components/PDFPreview.tsx
@@ -34,18 +34,16 @@ function PDFPreviewComponent({ request }: PDFPreviewProps) {
   ]);
 
   return (
-    <div className="border rounded-md shadow-sm bg-white dark:bg-neutral-900 dark:border-neutral-800 overflow-auto">
-      <div className="p-4 border-b dark:border-neutral-800">
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+    <div className="border rounded-md shadow-sm bg-white overflow-auto">
+      <div className="p-4 border-b">
+        <h2 className="text-xl font-semibold text-gray-900">
           PDF Preview
         </h2>
       </div>
 
       <div className="p-4 min-h-[300px]">
         {isMarkupEmpty ? (
-          <p className="text-gray-400 dark:text-gray-500 italic">
-            Enter some markdown content to see a preview
-          </p>
+          <p className="text-gray-400 italic">Enter some markdown content to see a preview</p>
         ) : (
           markdownContent
         )}

--- a/markup2pdf-webapp/app/globals.css
+++ b/markup2pdf-webapp/app/globals.css
@@ -35,18 +35,10 @@ body {
   overflow-x: auto;
 }
 
-.dark .prose pre {
-  background-color: #1e293b;
-}
-
 .prose code {
   background-color: rgba(0, 0, 0, 0.05);
   border-radius: 3px;
   padding: 0.2em 0.4em;
-}
-
-.dark .prose code {
-  background-color: rgba(255, 255, 255, 0.1);
 }
 
 .prose table {
@@ -65,9 +57,6 @@ body {
   background-color: #f5f7f9;
 }
 
-.dark .prose th {
-  background-color: #1e293b;
-}
 
 .prose blockquote {
   border-left: 4px solid #ddd;
@@ -76,7 +65,3 @@ body {
   margin-left: 0;
 }
 
-.dark .prose blockquote {
-  border-left-color: #334155;
-  color: #9ca3af;
-}


### PR DESCRIPTION
## Summary
- revert the dark mode styling in `globals.css`
- update the preview component so it always shows light mode styles

## Testing
- `npm run lint` *(fails: next not found)*
- `pytest` *(fails: ModuleNotFoundError: reportlab)*