### PR TITLE
Fix PDF preview colors

### DIFF
--- a/markup2pdf-webapp/app/components/PDFPreview.tsx
+++ b/markup2pdf-webapp/app/components/PDFPreview.tsx
@@ -34,16 +34,16 @@ function PDFPreviewComponent({ request }: PDFPreviewProps) {
   ]);
 
   return (
-    <div className="border rounded-md shadow-sm bg-white overflow-auto">
+    <div className="pdf-preview border rounded-md shadow-sm bg-white overflow-auto">
       <div className="p-4 border-b">
-        <h2 className="text-xl font-semibold text-gray-900">
-          PDF Preview
-        </h2>
+        <h2 className="text-xl font-semibold text-gray-900">PDF Preview</h2>
       </div>
 
       <div className="p-4 min-h-[300px]">
         {isMarkupEmpty ? (
-          <p className="text-gray-400 italic">Enter some markdown content to see a preview</p>
+          <p className="text-gray-400 italic">
+            Enter some markdown content to see a preview
+          </p>
         ) : (
           markdownContent
         )}

--- a/markup2pdf-webapp/app/globals.css
+++ b/markup2pdf-webapp/app/globals.css
@@ -57,7 +57,6 @@ body {
   background-color: #f5f7f9;
 }
 
-
 .prose blockquote {
   border-left: 4px solid #ddd;
   padding-left: 1rem;
@@ -65,3 +64,12 @@ body {
   margin-left: 0;
 }
 
+/* Ensure preview text always uses dark colors */
+.pdf-preview {
+  color: #171717;
+}
+
+.pdf-preview pre,
+.pdf-preview code {
+  color: #171717;
+}


### PR DESCRIPTION
## Summary
- add `pdf-preview` container class to keep preview text dark
- ensure code and pre elements use a readable color

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'reportlab')*