### PR TITLE
Fix font-family support

### DIFF
--- a/markup2pdf-backend/app/models/pdf_request.py
+++ b/markup2pdf-backend/app/models/pdf_request.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, Field, validator
+from app.services.font_service import font_service
 
 
 class SpacingOption(str, Enum):
@@ -22,4 +23,10 @@ class PDFGenerationRequest(BaseModel):
     def markup_must_not_be_empty(cls, v):
         if not v.strip():
             raise ValueError("Markup cannot be empty")
-        return v 
+        return v
+
+    @validator("font_family")
+    def font_family_available(cls, v):
+        if v and v not in font_service.get_available_fonts():
+            raise ValueError("Unsupported font family")
+        return v

--- a/markup2pdf-backend/app/services/font_service.py
+++ b/markup2pdf-backend/app/services/font_service.py
@@ -95,6 +95,32 @@ class FontService:
             self._monospace_font = "Courier"
             
         self._fonts_registered = True
+
+    def get_font_face_css(self, font_family: str) -> str:
+        """Return @font-face CSS for the given font family if available."""
+        css_rules = []
+        files = self.available_fonts.get(font_family)
+        if not files:
+            return ""
+
+        for style, filename in files.items():
+            font_weight = "bold" if "bold" in style else "normal"
+            font_style = "italic" if "italic" in style else "normal"
+
+            ext = Path(filename).suffix.lower()
+            if ext == ".woff2":
+                font_format = "woff2"
+            elif ext == ".otf":
+                font_format = "opentype"
+            else:
+                font_format = "truetype"
+
+            src = self.fonts_path / filename
+            css_rules.append(
+                f"@font-face {{ font-family: '{font_family}'; src: url('{src.as_posix()}') format('{font_format}'); font-weight: {font_weight}; font-style: {font_style}; }}"
+            )
+
+        return "\n".join(css_rules)
     
     def get_available_fonts(self) -> List[str]:
         """Return list of available font families"""

--- a/markup2pdf-backend/app/services/pdf_service.py
+++ b/markup2pdf-backend/app/services/pdf_service.py
@@ -60,6 +60,11 @@ tr:nth-child(even) {{ background: #f9f9f9; }}
 _FONT_STACKS = {
     "Inter": "Inter, 'DejaVu Sans', sans-serif",
     "Roboto": "Roboto, 'DejaVu Sans', sans-serif",
+    "SourceCodePro": "SourceCodePro, 'DejaVu Sans Mono', monospace",
+    "MesloLGS": "MesloLGS, 'DejaVu Sans Mono', monospace",
+    "Helvetica": "Helvetica, Arial, sans-serif",
+    "Times-Roman": "'Times New Roman', Times, serif",
+    "Courier": "Courier, monospace",
     "Serif": "serif",
 }
 
@@ -114,7 +119,9 @@ class PDFService:
         spacing_key = spacing_attr.name.lower() if hasattr(spacing_attr, "name") else str(spacing_attr).lower()
         line_height = _SPACING_LEVELS.get(spacing_key, 1.4)
 
-        font_stack = _FONT_STACKS.get(getattr(request, "font_family", "Inter"), "'DejaVu Sans', sans-serif")
+        requested_font = getattr(request, "font_family", "Inter")
+        font_stack = _FONT_STACKS.get(requested_font, "'DejaVu Sans', sans-serif")
+        font_face_css = font_service.get_font_face_css(requested_font)
         
         # Get the monospace font to use for code blocks
         monospace_font = font_service.get_monospace_font()
@@ -126,7 +133,11 @@ class PDFService:
             monospace_font=monospace_font
         )
 
-        return _PAGE_CSS + body_css
+        css_parts = [_PAGE_CSS]
+        if font_face_css:
+            css_parts.append(font_face_css)
+        css_parts.append(body_css)
+        return "\n".join(css_parts)
 
 
 # Singleton instance


### PR DESCRIPTION
## Summary
- validate requested font families
- expose `get_font_face_css` to produce `@font-face` CSS rules
- embed font-face CSS when generating PDFs
- expand font stack mappings

## Testing
- `python3 -m py_compile markup2pdf-backend/app/models/pdf_request.py markup2pdf-backend/app/services/pdf_service.py markup2pdf-backend/app/services/font_service.py`
- `python3 -m unittest discover markup2pdf-backend/app` *(fails: ImportError: Failed to import test module: api)*