### PR TITLE
Add CSS for list and heading elements

### DIFF
--- a/markup2pdf-backend/app/services/pdf_service.py
+++ b/markup2pdf-backend/app/services/pdf_service.py
@@ -52,6 +52,24 @@ th, td {{
 
 th {{ background: #f2f2f2; }}
 tr:nth-child(even) {{ background: #f9f9f9; }}
+
+ul, ol {{
+  margin: 1em 0;
+  padding-left: 1.5em;
+}}
+
+li {{ margin: 0.25em 0; }}
+
+h1, h2, h3, h4, h5, h6 {{
+  font-weight: 600;
+}}
+
+h1 {{ font-size: 2em; margin: 0.67em 0; }}
+h2 {{ font-size: 1.5em; margin: 0.75em 0; }}
+h3 {{ font-size: 1.17em; margin: 0.83em 0; }}
+h4 {{ font-size: 1em; margin: 1.12em 0; }}
+h5 {{ font-size: 0.83em; margin: 1.5em 0; }}
+h6 {{ font-size: 0.67em; margin: 1.67em 0; }}
 """
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- style list items and ordered lists in generated PDFs
- add h1-h6 rules so headings scale with the base font size

## Testing
- `source markup2pdf-backend/.venv/bin/activate && mypy app && pylint app` *(fails: No such file or directory)*
- `cd markup2pdf-backend && mypy app` *(fails: missing stubs)*
- `pylint app` *(fails: command not found)*
- `cd ../markup2pdf-webapp && npx eslint .` *(fails: cannot find package)*
- `npx tsc --noEmit` *(fails: cannot find module 'react')*