### PR TITLE
Read CSS styles from file

### DIFF
--- a/markup2pdf-backend/app/services/markdown_service.py
+++ b/markup2pdf-backend/app/services/markdown_service.py
@@ -78,7 +78,7 @@ def preserve_code_block_whitespace(html: str) -> str:
         'min-width: 40%; max-width: 100%; overflow-x: auto;"'
     )
     
-    html = re.sub(r'<pre>', f'<pre {pre_style}>', html)
+    #html = re.sub(r'<pre>', f'<pre {pre_style}>', html)
     
     # Ensure code inside pre tags maintains its formatting
     # This mainly addresses specific formatting issues with leading spaces and newlines
@@ -179,7 +179,7 @@ class MarkdownService:
 
     _extensions = [
         TableExtension(),
-        CodeHiliteExtension(css_class="code-highlight", pygments_style="github-dark", linenums=False),
+        CodeHiliteExtension(css_class="code-highlight", pygments_style="monokai", linenums=False),
         FencedCodeExtension(),  # Explicitly add fenced code extension
         ExtraExtension(),       # Add Extra extension which includes proper list support
         LineBreakExtension(),   # Add our custom line break extension
@@ -243,7 +243,7 @@ class MarkdownService:
         
         # Convert markdown to HTML
         html_body = markdown.markdown(cleaned, extensions=self._extensions)
-        
+
         # Ensure code blocks preserve whitespace
         html_body = preserve_code_block_whitespace(html_body)
         
@@ -269,16 +269,18 @@ class MarkdownService:
     <meta charset=\"utf-8\" />
     <style>
     {css}
+    div.code-highlight {{
+        margin-bottom: 16px;
+    }}
     pre {{
         white-space: pre-wrap;
         word-break: keep-all;
         tab-size: 4;
         -moz-tab-size: 4;
-        background-color: #f5f7f9;
         border-radius: 8px;
-        padding: 16px;
+        margin: 8px;
+        padding: 8px;
         font-family: {monospace_font}, monospace;
-        margin: 16px 0;
         display: inline-block;
         min-width: 40%;
         max-width: 100%;
@@ -287,6 +289,7 @@ class MarkdownService:
     code {{
         white-space: pre-wrap;
         font-family: {monospace_font}, monospace;
+
     }}
     /* List styling to support proper nesting */
     ul, ol {{

--- a/markup2pdf-backend/app/services/pdf_service.py
+++ b/markup2pdf-backend/app/services/pdf_service.py
@@ -170,7 +170,7 @@ class PDFService:
             css_parts.append(extra_css)
         if font_face_css:
             css_parts.append(font_face_css)
-        css_parts.append(body_css)
+        css_parts.append(body_css)          
         return "\n".join(css_parts)
 
 

--- a/markup2pdf-backend/app/services/pdf_service.py
+++ b/markup2pdf-backend/app/services/pdf_service.py
@@ -17,6 +17,19 @@ from app.models import PDFGenerationRequest
 from app.services.markdown_service import markdown_service
 from app.services.font_service import font_service
 
+# Path to custom CSS for PDF output
+_STYLES_CSS_PATH = (
+    Path(__file__).resolve().parent.parent / "static" / "css" / "styles.css"
+)
+
+
+def _read_styles_css() -> str:
+    """Return the contents of ``styles.css`` if the file exists."""
+    try:
+        return _STYLES_CSS_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
 # ---------------------------------------------------------------------------
 # CSS templates
 # ---------------------------------------------------------------------------
@@ -152,6 +165,9 @@ class PDFService:
         )
 
         css_parts = [_PAGE_CSS]
+        extra_css = _read_styles_css()
+        if extra_css:
+            css_parts.append(extra_css)
         if font_face_css:
             css_parts.append(font_face_css)
         css_parts.append(body_css)

--- a/markup2pdf-backend/app/static/css/styles.css
+++ b/markup2pdf-backend/app/static/css/styles.css
@@ -26,236 +26,249 @@ span.linenos.special {
   padding-right: 5px;
 }
 .code-highlight .hll {
-  background-color: #ffffcc;
+  background-color: #49483e;
 }
 .code-highlight {
-  background: #f8f8f8;
+  background: #272822;
+  color: #f8f8f2;
 }
 .code-highlight .c {
-  color: #3d7b7b;
-  font-style: italic;
+  color: #959077;
 } /* Comment */
 .code-highlight .err {
-  border: 1px solid #f00;
+  color: #ed007e;
+  background-color: #1e0010;
 } /* Error */
+.code-highlight .esc {
+  color: #f8f8f2;
+} /* Escape */
+.code-highlight .g {
+  color: #f8f8f2;
+} /* Generic */
 .code-highlight .k {
-  color: #008000;
-  font-weight: bold;
+  color: #66d9ef;
 } /* Keyword */
+.code-highlight .l {
+  color: #ae81ff;
+} /* Literal */
+.code-highlight .n {
+  color: #f8f8f2;
+} /* Name */
 .code-highlight .o {
-  color: #666;
+  color: #ff4689;
 } /* Operator */
+.code-highlight .x {
+  color: #f8f8f2;
+} /* Other */
+.code-highlight .p {
+  color: #f8f8f2;
+} /* Punctuation */
 .code-highlight .ch {
-  color: #3d7b7b;
-  font-style: italic;
+  color: #959077;
 } /* Comment.Hashbang */
 .code-highlight .cm {
-  color: #3d7b7b;
-  font-style: italic;
+  color: #959077;
 } /* Comment.Multiline */
 .code-highlight .cp {
-  color: #9c6500;
+  color: #959077;
 } /* Comment.Preproc */
 .code-highlight .cpf {
-  color: #3d7b7b;
-  font-style: italic;
+  color: #959077;
 } /* Comment.PreprocFile */
 .code-highlight .c1 {
-  color: #3d7b7b;
-  font-style: italic;
+  color: #959077;
 } /* Comment.Single */
 .code-highlight .cs {
-  color: #3d7b7b;
-  font-style: italic;
+  color: #959077;
 } /* Comment.Special */
 .code-highlight .gd {
-  color: #a00000;
+  color: #ff4689;
 } /* Generic.Deleted */
 .code-highlight .ge {
+  color: #f8f8f2;
   font-style: italic;
 } /* Generic.Emph */
 .code-highlight .ges {
+  color: #f8f8f2;
   font-weight: bold;
   font-style: italic;
 } /* Generic.EmphStrong */
 .code-highlight .gr {
-  color: #e40000;
+  color: #f8f8f2;
 } /* Generic.Error */
 .code-highlight .gh {
-  color: #000080;
-  font-weight: bold;
+  color: #f8f8f2;
 } /* Generic.Heading */
 .code-highlight .gi {
-  color: #008400;
+  color: #a6e22e;
 } /* Generic.Inserted */
 .code-highlight .go {
-  color: #717171;
+  color: #66d9ef;
 } /* Generic.Output */
 .code-highlight .gp {
-  color: #000080;
+  color: #ff4689;
   font-weight: bold;
 } /* Generic.Prompt */
 .code-highlight .gs {
+  color: #f8f8f2;
   font-weight: bold;
 } /* Generic.Strong */
 .code-highlight .gu {
-  color: #800080;
-  font-weight: bold;
+  color: #959077;
 } /* Generic.Subheading */
 .code-highlight .gt {
-  color: #04d;
+  color: #f8f8f2;
 } /* Generic.Traceback */
 .code-highlight .kc {
-  color: #008000;
-  font-weight: bold;
+  color: #66d9ef;
 } /* Keyword.Constant */
 .code-highlight .kd {
-  color: #008000;
-  font-weight: bold;
+  color: #66d9ef;
 } /* Keyword.Declaration */
 .code-highlight .kn {
-  color: #008000;
-  font-weight: bold;
+  color: #ff4689;
 } /* Keyword.Namespace */
 .code-highlight .kp {
-  color: #008000;
+  color: #66d9ef;
 } /* Keyword.Pseudo */
 .code-highlight .kr {
-  color: #008000;
-  font-weight: bold;
+  color: #66d9ef;
 } /* Keyword.Reserved */
 .code-highlight .kt {
-  color: #b00040;
+  color: #66d9ef;
 } /* Keyword.Type */
+.code-highlight .ld {
+  color: #e6db74;
+} /* Literal.Date */
 .code-highlight .m {
-  color: #666;
+  color: #ae81ff;
 } /* Literal.Number */
 .code-highlight .s {
-  color: #ba2121;
+  color: #e6db74;
 } /* Literal.String */
 .code-highlight .na {
-  color: #687822;
+  color: #a6e22e;
 } /* Name.Attribute */
 .code-highlight .nb {
-  color: #008000;
+  color: #f8f8f2;
 } /* Name.Builtin */
 .code-highlight .nc {
-  color: #00f;
-  font-weight: bold;
+  color: #a6e22e;
 } /* Name.Class */
 .code-highlight .no {
-  color: #800;
+  color: #66d9ef;
 } /* Name.Constant */
 .code-highlight .nd {
-  color: #a2f;
+  color: #a6e22e;
 } /* Name.Decorator */
 .code-highlight .ni {
-  color: #717171;
-  font-weight: bold;
+  color: #f8f8f2;
 } /* Name.Entity */
 .code-highlight .ne {
-  color: #cb3f38;
-  font-weight: bold;
+  color: #a6e22e;
 } /* Name.Exception */
 .code-highlight .nf {
-  color: #00f;
+  color: #a6e22e;
 } /* Name.Function */
 .code-highlight .nl {
-  color: #767600;
+  color: #f8f8f2;
 } /* Name.Label */
 .code-highlight .nn {
-  color: #00f;
-  font-weight: bold;
+  color: #f8f8f2;
 } /* Name.Namespace */
+.code-highlight .nx {
+  color: #a6e22e;
+} /* Name.Other */
+.code-highlight .py {
+  color: #f8f8f2;
+} /* Name.Property */
 .code-highlight .nt {
-  color: #008000;
-  font-weight: bold;
+  color: #ff4689;
 } /* Name.Tag */
 .code-highlight .nv {
-  color: #19177c;
+  color: #f8f8f2;
 } /* Name.Variable */
 .code-highlight .ow {
-  color: #a2f;
-  font-weight: bold;
+  color: #ff4689;
 } /* Operator.Word */
+.code-highlight .pm {
+  color: #f8f8f2;
+} /* Punctuation.Marker */
 .code-highlight .w {
-  color: #bbb;
+  color: #f8f8f2;
 } /* Text.Whitespace */
 .code-highlight .mb {
-  color: #666;
+  color: #ae81ff;
 } /* Literal.Number.Bin */
 .code-highlight .mf {
-  color: #666;
+  color: #ae81ff;
 } /* Literal.Number.Float */
 .code-highlight .mh {
-  color: #666;
+  color: #ae81ff;
 } /* Literal.Number.Hex */
 .code-highlight .mi {
-  color: #666;
+  color: #ae81ff;
 } /* Literal.Number.Integer */
 .code-highlight .mo {
-  color: #666;
+  color: #ae81ff;
 } /* Literal.Number.Oct */
 .code-highlight .sa {
-  color: #ba2121;
+  color: #e6db74;
 } /* Literal.String.Affix */
 .code-highlight .sb {
-  color: #ba2121;
+  color: #e6db74;
 } /* Literal.String.Backtick */
 .code-highlight .sc {
-  color: #ba2121;
+  color: #e6db74;
 } /* Literal.String.Char */
 .code-highlight .dl {
-  color: #ba2121;
+  color: #e6db74;
 } /* Literal.String.Delimiter */
 .code-highlight .sd {
-  color: #ba2121;
-  font-style: italic;
+  color: #e6db74;
 } /* Literal.String.Doc */
 .code-highlight .s2 {
-  color: #ba2121;
+  color: #e6db74;
 } /* Literal.String.Double */
 .code-highlight .se {
-  color: #aa5d1f;
-  font-weight: bold;
+  color: #ae81ff;
 } /* Literal.String.Escape */
 .code-highlight .sh {
-  color: #ba2121;
+  color: #e6db74;
 } /* Literal.String.Heredoc */
 .code-highlight .si {
-  color: #a45a77;
-  font-weight: bold;
+  color: #e6db74;
 } /* Literal.String.Interpol */
 .code-highlight .sx {
-  color: #008000;
+  color: #e6db74;
 } /* Literal.String.Other */
 .code-highlight .sr {
-  color: #a45a77;
+  color: #e6db74;
 } /* Literal.String.Regex */
 .code-highlight .s1 {
-  color: #ba2121;
+  color: #e6db74;
 } /* Literal.String.Single */
 .code-highlight .ss {
-  color: #19177c;
+  color: #e6db74;
 } /* Literal.String.Symbol */
 .code-highlight .bp {
-  color: #008000;
+  color: #f8f8f2;
 } /* Name.Builtin.Pseudo */
 .code-highlight .fm {
-  color: #00f;
+  color: #a6e22e;
 } /* Name.Function.Magic */
 .code-highlight .vc {
-  color: #19177c;
+  color: #f8f8f2;
 } /* Name.Variable.Class */
 .code-highlight .vg {
-  color: #19177c;
+  color: #f8f8f2;
 } /* Name.Variable.Global */
 .code-highlight .vi {
-  color: #19177c;
+  color: #f8f8f2;
 } /* Name.Variable.Instance */
 .code-highlight .vm {
-  color: #19177c;
+  color: #f8f8f2;
 } /* Name.Variable.Magic */
 .code-highlight .il {
-  color: #666;
+  color: #ae81ff;
 } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
## Summary
- load custom PDF CSS from `static/css/styles.css`
- include these rules when building PDF style sheet

## Testing
- `mypy app && pylint app` *(fails: Library stubs not installed and lint issues)*