### PR TITLE
Switch frontend to shadcn components

### DIFF
--- a/markup2pdf-webapp/app/components/FilenameInput.tsx
+++ b/markup2pdf-webapp/app/components/FilenameInput.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useCallback, memo, useEffect } from "react";
 import { useFilename } from "./FormattingContext";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 
 interface FilenameInputProps {
   className?: string;
@@ -27,20 +29,17 @@ function FilenameInputComponent({ className }: FilenameInputProps) {
 
   return (
     <div className={className}>
-      <label
-        htmlFor="filename"
-        className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-      >
+      <Label htmlFor="filename" className="mb-1">
         Filename (optional)
-      </label>
-      <input
+      </Label>
+      <Input
         type="text"
         id="filename"
         name="filename"
         placeholder="Optional filename"
         value={localFilename}
         onChange={handleChange}
-        className="block w-full rounded-md border p-2 h-10 text-gray-900 dark:text-gray-100 bg-white dark:bg-neutral-900 border-gray-300 dark:border-neutral-700 focus:border-blue-500 focus:ring-blue-500"
+        className="h-10"
       />
     </div>
   );

--- a/markup2pdf-webapp/app/components/FormattingContext.tsx
+++ b/markup2pdf-webapp/app/components/FormattingContext.tsx
@@ -175,18 +175,6 @@ export function FormattingProvider({ children }: { children: ReactNode }) {
     [resetToDefaults]
   );
 
-  // For backward compatibility, create a merged options object
-  const options = useMemo(
-    () => ({
-      fontFamily: typography.fontFamily,
-      availableFonts: typography.availableFonts,
-      sizeLevel: typography.sizeLevel,
-      spacing: layout.spacing,
-      autoWidthTables: layout.autoWidthTables,
-      filename,
-    }),
-    [typography, layout, filename]
-  );
 
   return (
     <ResetContext.Provider value={resetValue}>

--- a/markup2pdf-webapp/app/components/GenerateButton.tsx
+++ b/markup2pdf-webapp/app/components/GenerateButton.tsx
@@ -2,6 +2,7 @@ import React, { memo } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { api, PDFGenerationRequest } from "../lib/api";
 import { savePDF, getTimestampForFilename } from "../lib/utils";
+import { Button } from "@/components/ui/button";
 
 interface GenerateButtonProps {
   request: PDFGenerationRequest;
@@ -30,12 +31,10 @@ function GenerateButtonComponent({
 
   return (
     <div>
-      <button
+      <Button
         onClick={() => generatePdfMutation.mutate(request)}
         disabled={disabled || isLoading}
-        className={`w-full h-8 px-4 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md flex items-center justify-center transition-colors
-          ${disabled || isLoading ? "opacity-50 cursor-not-allowed" : ""}
-        `}
+        className="w-full h-8"
       >
         {isLoading ? (
           <>
@@ -64,7 +63,7 @@ function GenerateButtonComponent({
         ) : (
           "Generate PDF"
         )}
-      </button>
+      </Button>
 
       {hasError && (
         <div className="text-red-500 text-sm text-center mt-2">

--- a/markup2pdf-webapp/app/components/LayoutPanel.tsx
+++ b/markup2pdf-webapp/app/components/LayoutPanel.tsx
@@ -1,6 +1,9 @@
 import React, { memo } from "react";
 import { useLayout } from "./FormattingContext";
 import { SpacingOption } from "../lib/api";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 
 function LayoutPanelComponent() {
   const { spacing, autoWidthTables, setSpacing, setAutoWidthTables } =
@@ -14,38 +17,25 @@ function LayoutPanelComponent() {
 
       <div className="grid grid-cols-1 gap-4">
         <div className="space-y-2">
-          <label
-            htmlFor="spacing"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
-          >
-            Spacing
-          </label>
-          <select
+          <Label htmlFor="spacing">Spacing</Label>
+          <Select
             id="spacing"
             value={spacing}
             onChange={(e) => setSpacing(e.target.value as SpacingOption)}
-            className="w-full p-2 text-sm border border-gray-300 dark:border-neutral-700 rounded-md bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           >
             <option value={SpacingOption.DEFAULT}>Default</option>
             <option value={SpacingOption.COMPACT}>Compact</option>
             <option value={SpacingOption.SPACIOUS}>Spacious</option>
-          </select>
+          </Select>
         </div>
 
         <div className="flex items-center space-x-2">
-          <input
-            type="checkbox"
+          <Switch
             id="auto-width-tables"
             checked={autoWidthTables}
             onChange={(e) => setAutoWidthTables(e.target.checked)}
-            className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-neutral-700 rounded"
           />
-          <label
-            htmlFor="auto-width-tables"
-            className="text-sm font-medium text-gray-700 dark:text-gray-300"
-          >
-            Auto-width tables
-          </label>
+          <Label htmlFor="auto-width-tables">Auto-width tables</Label>
         </div>
       </div>
     </div>

--- a/markup2pdf-webapp/app/components/MarkupEditor.tsx
+++ b/markup2pdf-webapp/app/components/MarkupEditor.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef, memo, useCallback } from "react";
+import React, { useRef, memo, useCallback } from "react";
 import { cn } from "../lib/utils";
+import { Textarea } from "@/components/ui/textarea";
 
 interface MarkupEditorProps {
   value: string;
@@ -24,11 +25,11 @@ function MarkupEditorComponent({
 
   return (
     <div className={cn("relative w-full", className)}>
-      <textarea
+      <Textarea
         ref={textareaRef}
         value={value}
         onChange={handleChange}
-        className="w-full min-h-[300px] h-[300px] p-4 font-mono text-sm text-gray-900 dark:text-gray-100 bg-white dark:bg-neutral-900 border border-gray-300 dark:border-neutral-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none placeholder:text-gray-400 dark:placeholder:text-gray-500"
+        className="w-full min-h-[300px] h-[300px] font-mono resize-none"
         placeholder="# Enter your markdown here
 
 ## Example Content
@@ -49,7 +50,7 @@ console.log('Code block example');
 
 > This is a blockquote
 
-[Link example](https://example.com)"
+        [Link example](https://example.com)"
       />
     </div>
   );

--- a/markup2pdf-webapp/app/components/TypographyPanel.tsx
+++ b/markup2pdf-webapp/app/components/TypographyPanel.tsx
@@ -1,6 +1,9 @@
 import React, { memo } from "react";
 import { useTypography } from "./FormattingContext";
 import { sizeLevelToName } from "../lib/utils";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
 
 function TypographyPanelComponent() {
   const { fontFamily, availableFonts, sizeLevel, setFontFamily, setSizeLevel } =
@@ -14,36 +17,24 @@ function TypographyPanelComponent() {
 
       <div className="grid grid-cols-1 gap-4">
         <div className="space-y-2">
-          <label
-            htmlFor="font-family"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
-          >
-            Font Family
-          </label>
-          <select
+          <Label htmlFor="font-family">Font Family</Label>
+          <Select
             id="font-family"
             value={fontFamily}
             onChange={(e) => setFontFamily(e.target.value)}
-            className="w-full p-2 text-sm border border-gray-300 dark:border-neutral-700 rounded-md bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           >
             {availableFonts.map((font) => (
               <option key={font} value={font}>
                 {font}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
 
         <div className="space-y-2">
-          <label
-            htmlFor="size-level"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
-          >
-            Size Level
-          </label>
+          <Label htmlFor="size-level">Size Level</Label>
           <div className="flex items-center space-x-2">
-            <input
-              type="range"
+            <Slider
               id="size-level"
               min={1}
               max={5}
@@ -52,7 +43,7 @@ function TypographyPanelComponent() {
               onChange={(e) => setSizeLevel(Number(e.target.value))}
               className="w-3/4"
             />
-            <span className="text-sm font-medium w-32 text-gray-900 dark:text-gray-100">
+            <span className="text-sm font-medium w-32">
               {sizeLevelToName(sizeLevel)}
             </span>
           </div>

--- a/markup2pdf-webapp/app/globals.css
+++ b/markup2pdf-webapp/app/globals.css
@@ -2,29 +2,56 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
+@layer base {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: 0 0% 100%;
+    --foreground: 24 9.8% 10%;
+    --card: 0 0% 100%;
+    --card-foreground: 24 9.8% 10%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 24 9.8% 10%;
+    --primary: 24 94% 50%;
+    --primary-foreground: 60 9.1% 97.8%;
+    --secondary: 60 4.8% 95.9%;
+    --secondary-foreground: 24 9.8% 10%;
+    --muted: 60 4.8% 95.9%;
+    --muted-foreground: 25 5.3% 44.7%;
+    --accent: 60 4.8% 95.9%;
+    --accent-foreground: 24 9.8% 10%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 20 5.9% 90%;
+    --input: 20 5.9% 90%;
+    --ring: 24 94% 50%;
+    --radius: 0.5rem;
   }
-}
+  .dark {
+    --background: 20 14.3% 4.1%;
+    --foreground: 60 9.1% 97.8%;
+    --card: 24 9.8% 10%;
+    --card-foreground: 60 9.1% 97.8%;
+    --popover: 24 9.8% 10%;
+    --popover-foreground: 60 9.1% 97.8%;
+    --primary: 24 94% 50%;
+    --primary-foreground: 60 9.1% 97.8%;
+    --secondary: 12 6.5% 15.1%;
+    --secondary-foreground: 60 9.1% 97.8%;
+    --muted: 12 6.5% 15.1%;
+    --muted-foreground: 24 5.4% 63.9%;
+    --accent: 12 6.5% 15.1%;
+    --accent-foreground: 60 9.1% 97.8%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 60 9.1% 97.8%;
+    --border: 12 6.5% 15.1%;
+    --input: 12 6.5% 15.1%;
+    --ring: 24 94% 50%;
+  }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-inter), sans-serif;
+  body {
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-family: var(--font-inter), sans-serif;
+  }
 }
 
 /* Custom styling for code blocks in markdown preview */

--- a/markup2pdf-webapp/app/page.tsx
+++ b/markup2pdf-webapp/app/page.tsx
@@ -66,7 +66,7 @@ function EditorPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-neutral-900 dark:to-neutral-800 flex flex-col text-gray-900 dark:text-gray-100">
-      <header className="bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow">
+      <header className="bg-gradient-to-r from-orange-600 to-orange-400 text-white shadow">
         <div className="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
           <h1 className="text-2xl font-bold">Markdown to PDF Converter</h1>
         </div>

--- a/markup2pdf-webapp/components/ui/button.tsx
+++ b/markup2pdf-webapp/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { cn } from "@/app/lib/utils";
+
+const baseClasses =
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50";
+
+const variantClasses = {
+  default: "bg-primary text-primary-foreground hover:bg-primary/90",
+  destructive:
+    "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+  outline:
+    "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+  secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+  ghost: "hover:bg-accent hover:text-accent-foreground",
+  link: "text-primary underline-offset-4 hover:underline",
+} as const;
+
+const sizeClasses = {
+  default: "h-10 px-4 py-2",
+  sm: "h-9 rounded-md px-3",
+  lg: "h-11 rounded-md px-8",
+  icon: "h-10 w-10",
+} as const;
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: keyof typeof variantClasses;
+  size?: keyof typeof sizeClasses;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      variant = "default",
+      size = "default",
+      ...props
+    },
+    ref
+  ) => (
+    <button
+      ref={ref}
+      className={cn(
+        baseClasses,
+        variantClasses[variant],
+        sizeClasses[size],
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Button.displayName = "Button";

--- a/markup2pdf-webapp/components/ui/input.tsx
+++ b/markup2pdf-webapp/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "@/app/lib/utils";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = "text", ...props }, ref) => (
+    <input
+      ref={ref}
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Input.displayName = "Input";

--- a/markup2pdf-webapp/components/ui/label.tsx
+++ b/markup2pdf-webapp/components/ui/label.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { cn } from "@/app/lib/utils";
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(
+        "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Label.displayName = "Label";

--- a/markup2pdf-webapp/components/ui/select.tsx
+++ b/markup2pdf-webapp/components/ui/select.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { cn } from "@/app/lib/utils";
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => (
+    <select
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </select>
+  )
+);
+Select.displayName = "Select";

--- a/markup2pdf-webapp/components/ui/slider.tsx
+++ b/markup2pdf-webapp/components/ui/slider.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "@/app/lib/utils";
+
+export type SliderProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      type="range"
+      ref={ref}
+      className={cn(
+        "w-full h-2 cursor-pointer appearance-none rounded-lg bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Slider.displayName = "Slider";

--- a/markup2pdf-webapp/components/ui/switch.tsx
+++ b/markup2pdf-webapp/components/ui/switch.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "@/app/lib/utils";
+
+export type SwitchProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={cn(
+        "h-4 w-4 rounded border-input text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Switch.displayName = "Switch";

--- a/markup2pdf-webapp/components/ui/textarea.tsx
+++ b/markup2pdf-webapp/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { cn } from "@/app/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Textarea.displayName = "Textarea";

--- a/markup2pdf-webapp/tailwind.config.js
+++ b/markup2pdf-webapp/tailwind.config.js
@@ -1,12 +1,60 @@
+import typography from "@tailwindcss/typography";
+
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ["./app/**/*.{js,ts,jsx,tsx,mdx}"],
+  darkMode: ["class"],
+  content: ["./app/**/*.{js,ts,jsx,tsx,mdx}", "./components/**/*.{js,ts,jsx,tsx}"] ,
   theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
     extend: {
       fontFamily: {
         sans: ["var(--font-inter)", "sans-serif"],
       },
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+      },
     },
   },
-  plugins: [require("@tailwindcss/typography")],
+  plugins: [typography],
 };


### PR DESCRIPTION
## Summary
- add basic shadcn style UI components
- use the new UI components in the app
- switch Tailwind config and globals to shadcn "orange" theme
- update header gradient

## Testing
- `npx eslint .`
